### PR TITLE
Expose channel name as message.from

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ gem 'ruboty-slack_rtm'
 - `SLACK_TOKEN`: Account's token. get one on https://api.slack.com/web#basics
 - `SLACK_EXPOSE_CHANNEL_NAME_AS_FROM`: if this set to 1, `message.from` will be channel name instead of id (optional)
 
-Do not requires real user account. using with bot is recommended.
-
-see: https://api.slack.com/bot-users
+This adapter doesn't require a real user account. Using with bot integration's API token is recommended.
+See: https://api.slack.com/bot-users
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ gem 'ruboty-slack_rtm'
 
 ## ENV
 
-```
-SLACK_TOKEN - Account's token. get one on https://api.slack.com/web#basics
-```
+- `SLACK_TOKEN`: Account's token. get one on https://api.slack.com/web#basics
+- `SLACK_EXPOSE_CHANNEL_NAME_AS_FROM`: if this set to 1, `message.from` will be channel name instead of id (optional)
 
 Do not requires real user account. using with bot is recommended.
 


### PR DESCRIPTION
Previously SlackRTM adapter sends message to robots with channel ID. Some adapters (e.g. ruboty-kokodeikku) changes their behavior using `message.from`.

But channel ID is not friendly for human, so this patch adds ability to change message.from to channel name, instead of ID.
