### PR TITLE
Fix #2 -- SLACK_EXPOSE_CHANNEL_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ gem 'ruboty-slack_rtm'
 ## ENV
 
 - `SLACK_TOKEN`: Account's token. get one on https://api.slack.com/web#basics
-- `SLACK_EXPOSE_CHANNEL_NAME_AS_FROM`: if this set to 1, `message.from` will be channel name instead of id (optional)
+- `SLACK_EXPOSE_CHANNEL_NAME`: if this set to 1, `message.to` will be channel name instead of id (optional)
 
 This adapter doesn't require a real user account. Using with bot integration's API token is recommended.
 See: https://api.slack.com/bot-users

--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -7,7 +7,7 @@ module Ruboty
   module Adapters
     class SlackRTM < Base
       env :SLACK_TOKEN, "Account's token. get one on https://api.slack.com/web#basics"
-      env :SLACK_EXPOSE_CHANNEL_NAME_AS_FROM, "if this set to 1, message.from will be channel name instead of id", optional: true
+      env :SLACK_EXPOSE_CHANNEL_NAME, "if this set to 1, message.to will be channel name instead of id", optional: true
 
       def run
         init
@@ -74,11 +74,11 @@ module Ruboty
         @realtime ||= ::SlackRTM::Client.new(websocket_url: url)
       end
 
-      def expose_channel_name_as_from?
-        if @expose_channel_name_as_from.nil?
-          @expose_channel_name_as_from = ENV['SLACK_EXPOSE_CHANNEL_NAME_AS_FROM'] == '1'
+      def expose_channel_name?
+        if @expose_channel_name.nil?
+          @expose_channel_name = ENV['SLACK_EXPOSE_CHANNEL_NAME'] == '1'
         else
-          @expose_channel_name_as_from
+          @expose_channel_name
         end
       end
 
@@ -93,13 +93,13 @@ module Ruboty
         user = user_info(data['user']) || {}
 
         channel = channel_info(data['channel'])
-        channel_from = expose_channel_name_as_from? ? "##{channel['name']}" : channel['id']
+        channel_to = expose_channel_name? ? "##{channel['name']}" : channel['id']
 
         robot.receive(
           body: data['text'],
-          from: channel_from,
+          from: data['channel'],
           from_name: user['name'],
-          to: data['channel'],
+          to: channel_to,
           channel: channel,
           user: user,
           mention_to: data['mention_to'],

--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -93,7 +93,11 @@ module Ruboty
         user = user_info(data['user']) || {}
 
         channel = channel_info(data['channel'])
-        channel_to = expose_channel_name? ? "##{channel['name']}" : channel['id']
+        if channel
+          channel_to = expose_channel_name? ? "##{channel['name']}" : channel['id']
+        else # direct message
+          channel_to = data['channel']
+        end
 
         robot.receive(
           body: data['text'],


### PR DESCRIPTION
Pull request #2 isn't correct. :pray:

This patch renames SLACK_EXPOSE_CHANNEL_NAME_AS_FROM env var to SLACK_EXPOSE_CHANNEL_NAME. Also, previous patch (#2) touches to `message.from`, but this patch makes it to touch `message.to`.

Message's `from` and `to` is supposed to be like an email header.

Let's see other existing adapter.
- XMPP based adapter (e.g. ruboty-slack):
  - In channels, `from` is a combination of room ID and user ID, and `to` is a room ID.
  - In private messages, `from` and `to` are both user ID.

And our previous behavior is this:

  In channels, `from` is a room ID. `from_name` is a user name. And `to` is a room ID.

Okay. Ideally `from` should be a combination of room and user ID... But it breaks existing stuff. So this patch reverts `from` behavior to before #2, and makes `to` customizable.
