### PR TITLE
Unescape body

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 require 'time'
 require 'slack'
 require 'slack-rtmapi'
@@ -100,7 +101,7 @@ module Ruboty
         end
 
         robot.receive(
-          body: data['text'],
+          body: CGI.unescapeHTML(data['text']),
           from: data['channel'],
           from_name: user['name'],
           to: channel_to,


### PR DESCRIPTION
Escaped the unescaped text.
For example, can't use https://github.com/r7kamura/ruboty-alias.
https://api.slack.com/docs/formatting
