### PR TITLE
Add SLACK_IGNORE_GENERAL option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ gem 'ruboty-slack_rtm'
 
 - `SLACK_TOKEN`: Account's token. get one on https://api.slack.com/web#basics
 - `SLACK_EXPOSE_CHANNEL_NAME`: if this set to 1, `message.to` will be channel name instead of id (optional)
+- `SLACK_IGNORE_GENERAL`: if this set to 1, bot ignores all messages on #general channel (optional)
 
 This adapter doesn't require a real user account. Using with bot integration's API token is recommended.
 See: https://api.slack.com/bot-users

--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -9,6 +9,7 @@ module Ruboty
     class SlackRTM < Base
       env :SLACK_TOKEN, "Account's token. get one on https://api.slack.com/web#basics"
       env :SLACK_EXPOSE_CHANNEL_NAME, "if this set to 1, message.to will be channel name instead of id", optional: true
+      env :SLACK_IGNORE_GENERAL, "if this set to 1, bot ignores all messages on #general channel", optional: true
 
       def run
         init
@@ -94,7 +95,10 @@ module Ruboty
         user = user_info(data['user']) || {}
 
         channel = channel_info(data['channel'])
+
         if channel
+          return if channel['name'] == 'general' && ENV['SLACK_IGNORE_GENERAL'] == '1'
+
           channel_to = expose_channel_name? ? "##{channel['name']}" : channel['id']
         else # direct message
           channel_to = data['channel']


### PR DESCRIPTION
Slack adds all accounts to #general channel automatically.
But in some cases, we want to deal bots just only specific channels.

With this option, we can stop all action of bot on #general channel.
