### PR TITLE
resolve at here mention

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -151,7 +151,7 @@ module Ruboty
           "@#{name}"
         end
 
-        data['text'].gsub!(/\<!(?<special>[^>]+)\>/) do |_|
+        data['text'].gsub!(/\<!(?<special>[^>|@]+)(\|\@[^>]+)?\>/) do |_|
           "@#{Regexp.last_match[:special]}"
         end
 
@@ -189,7 +189,7 @@ module Ruboty
           msg
         end
 
-        text.gsub!(/@(?<special>(?:everyone|group|channel))/) do |_|
+        text.gsub!(/@(?<special>(?:everyone|group|channel|here))/) do |_|
           "<!#{Regexp.last_match[:special]}>"
         end
 


### PR DESCRIPTION
### Fix

Resolve at here mention
### What I got

<img width="275" alt="2015-10-24 18 36 50" src="https://cloud.githubusercontent.com/assets/2846039/10710002/6d0bd806-7a7e-11e5-8872-8efbae0ede1c.png">
### What I expected

<img width="255" alt="2015-10-24 18 36 35" src="https://cloud.githubusercontent.com/assets/2846039/10710004/7b74a922-7a7e-11e5-98e6-d0627a514e50.png">
### JSON

JSON got from RTM API

```
{"type"=>"message", "channel"=>"xxxxxxx", "user"=>"xxxxxxx", "text"=>"<@xxxxxxx>: echo <!here|@here> hi!", "ts"=>"1445679274.000024", "team"=>"xxxx"}
```
## Concern

There is no documentation about at here mention in RTM API page
I have worries about is regexp format correct?
https://api.slack.com/events/message
