### PR TITLE
Add resolve code for user groups

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -205,6 +205,18 @@ module Ruboty
           "<!#{Regexp.last_match[:special]}>"
         end
 
+        text.gsub!(/@(?<subteam_name>[0-9a-z._-]+)/) do |_|
+          subteam_name = Regexp.last_match[:subteam_name]
+          msg = "@#{subteam_name}"
+
+          @usergroup_info_caches.each_pair do |id, usergroup|
+            if usergroup && usergroup['handle'] == subteam_name
+              msg = "<!subteam^#{usergroup['id']}>"
+            end
+          end
+          msg
+        end
+
         text.gsub!(/\#(?<room_id>[a-z0-9_-]+)/) do |_|
           room_id = Regexp.last_match[:room_id]
           msg = "##{room_id}"

--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -295,8 +295,9 @@ module Ruboty
       end
 
       def usergroup_info(usergroup_id)
-        @usergroup_info_caches[usergroup_id] ||= begin
+        @usergroup_info_caches[usergroup_id] || begin
           make_usergroups_cache
+          @usergroup_info_caches[usergroup_id]
         end
       end
     end


### PR DESCRIPTION
# before

![2015-12-07 18 43 16](https://cloud.githubusercontent.com/assets/795891/11623863/110f0dc2-9d13-11e5-81e3-e952a98f5252.png)
# after

![2015-12-07 18 47 09](https://cloud.githubusercontent.com/assets/795891/11623872/2834e846-9d13-11e5-827c-6a773c4adf12.png)

---

https://get.slack.help/hc/en-us/articles/212906697-User-Groups

> For paid teams there is an additional command for user groups that follows the format <!subteam^ID|handle>.
> https://api.slack.com/docs/formatting
