### PR TITLE
Use websocket-client-simple instead of slack-rtmapi

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -67,7 +67,12 @@ module Ruboty
       end
 
       def url
-        @url ||= ::SlackRTM.get_url(token: ENV['SLACK_TOKEN'])
+        @url ||= begin
+          response = Net::HTTP.post_form(URI.parse('https://slack.com/api/rtm.start'), token: ENV['SLACK_TOKEN'])
+          body = JSON.parse(response.body)
+
+          URI.parse(body['url'])
+        end
       end
 
       def client

--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -1,7 +1,6 @@
 require 'cgi'
 require 'time'
 require 'slack'
-require 'slack-rtmapi'
 require 'ruboty/adapters/base'
 
 module Ruboty
@@ -76,7 +75,7 @@ module Ruboty
       end
 
       def realtime
-        @realtime ||= ::SlackRTM::Client.new(websocket_url: url)
+        @realtime ||= ::Ruboty::SlackRTM::Client.new(websocket_url: url)
       end
 
       def expose_channel_name?

--- a/lib/ruboty/slack_rtm.rb
+++ b/lib/ruboty/slack_rtm.rb
@@ -1,2 +1,3 @@
 require 'ruboty/slack_rtm/version'
+require 'ruboty/slack_rtm/client'
 require 'ruboty/adapters/slack_rtm'

--- a/lib/ruboty/slack_rtm/client.rb
+++ b/lib/ruboty/slack_rtm/client.rb
@@ -1,0 +1,31 @@
+require 'json'
+require 'websocket-client-simple'
+
+module Ruboty
+  module SlackRTM
+    class Client
+      def initialize(websocket_url:)
+        @client = WebSocket::Client::Simple.connect(websocket_url.to_s)
+        @queue = Queue.new
+      end
+
+      def send(data)
+        data[:id] = Time.now.to_i * 10 + rand(10)
+        @queue.enq(data.to_json)
+      end
+
+      def on(event, &block)
+        @client.on(event) do |message|
+          block.call(JSON.parse(message.data))
+        end
+      end
+
+      def main_loop
+        loop do
+          message = @queue.deq
+          @client.send(message)
+        end
+      end
+    end
+  end
+end

--- a/ruboty-slack_rtm.gemspec
+++ b/ruboty-slack_rtm.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ruboty', '>= 1.1.4'
   spec.add_dependency 'slack-api', '~> 1.0.0'
-  spec.add_dependency 'slack-rtmapi', '~> 1.0.0.rc4'
+  spec.add_dependency 'websocket-client-simple', '~> 0.3.0'
 end


### PR DESCRIPTION
## Problem

slack-rtmapi has a problem around executing shell command. For example, following handler does not work as we are expected to. We get a first message after the sleep command is finished.

``` ruby
module Ruboty
  module Handlers
    class Sleep < Ruboty::Handlers::Base
      on /sleep\s+(?<sec>\d+)/i, name: 'sleep', description: 'run sleep command'

      def sleep(message)
        sec = message[:sec].to_i
        message.reply("Sleep #{sec} sec")
        `sleep #{sec}`
        message.reply("Wake up!")
      end
    end
  end
end
```
## Solution

We could try using [websocket-client-simple](https://github.com/shokai/websocket-client-simple) that is clean thread-based implementation and works fine.
