### PR TITLE
Send ping every 30 seconds

### DIFF
--- a/lib/ruboty/slack_rtm/client.rb
+++ b/lib/ruboty/slack_rtm/client.rb
@@ -21,9 +21,22 @@ module Ruboty
       end
 
       def main_loop
+        keep_connection
+
         loop do
           message = @queue.deq
           @client.send(message)
+        end
+      end
+
+      private
+
+      def keep_connection
+        Thread.start do
+          loop do
+            sleep(30)
+            @client.send(type: 'ping')
+          end
         end
       end
     end


### PR DESCRIPTION
WebSocket::Client::Simple does not support WebSocket ping spec, so we need to send ping message as message.
