### PR TITLE
Set verify_mode explicitly

### DIFF
--- a/lib/ruboty/slack_rtm/client.rb
+++ b/lib/ruboty/slack_rtm/client.rb
@@ -33,7 +33,7 @@ module Ruboty
       private
 
       def create_client(url)
-        WebSocket::Client::Simple.connect(url).tap do |client|
+        WebSocket::Client::Simple.connect(url, verify_mode: OpenSSL::SSL::VERIFY_PEER).tap do |client|
           client.on(:error) do |err|
             Ruboty.logger.error("#{err.class}: #{err.message}\n#{err.backtrace.join("\n")}")
           end


### PR DESCRIPTION
websocket-client-simple have deprecated and insecure defaults of
SSLContext.
https://github.com/shokai/websocket-client-simple/blob/v0.3.0/lib/websocket-client-simple/client.rb
