### PR TITLE
Rename Client#on to Client#on_text

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -49,7 +49,7 @@ module Ruboty
       end
 
       def bind
-        realtime.on(:message) do |data|
+        realtime.on_text do |data|
           method_name = "on_#{data['type']}".to_sym
           send(method_name, data) if respond_to?(method_name, true)
         end

--- a/lib/ruboty/slack_rtm/client.rb
+++ b/lib/ruboty/slack_rtm/client.rb
@@ -15,8 +15,8 @@ module Ruboty
         @queue.enq(data.to_json)
       end
 
-      def on(event, &block)
-        @client.on(event) do |message|
+      def on_text(&block)
+        @client.on(:message) do |message|
           case message.type
           when :ping
             Ruboty.logger.debug("#{Client.name}: Received ping message")


### PR DESCRIPTION
The block given to Client#on is now called only when "text" message, so
`on_text` is more appreciate name.
