### PR TITLE
Don't override Ruby's core method

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -25,7 +25,7 @@ module Ruboty
 
         return unless channel
 
-        realtime.send(
+        realtime.send_message(
           type: 'message',
           channel: channel,
           text: message[:code] ?  "```\n#{message[:body]}\n```" : resolve_send_mention(message[:body]),

--- a/lib/ruboty/slack_rtm/client.rb
+++ b/lib/ruboty/slack_rtm/client.rb
@@ -10,7 +10,7 @@ module Ruboty
         @queue = Queue.new
       end
 
-      def send(data)
+      def send_message(data)
         data[:id] = Time.now.to_i * 10 + rand(10)
         @queue.enq(data.to_json)
       end


### PR DESCRIPTION
`send` is a core method in Ruby, so let's not override it to avoid
confusion.
