### PR TITLE
check `is_bot` parameter for ignoring bot_messages

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -103,7 +103,7 @@ module Ruboty
 
         channel = channel_info(data['channel'])
 
-        if data['subtype'] == 'bot_message' && ENV['SLACK_IGNORE_BOT_MESSAGE'] == '1'
+        if (data['subtype'] == 'bot_message' || user['is_bot']) && ENV['SLACK_IGNORE_BOT_MESSAGE'] == '1'
           return
         end
 


### PR DESCRIPTION
[bot integration user](https://slack.com/apps/A0F7YS25R-bots)'s message does not have `subtype` 😢 
