### PR TITLE
Support attachments option

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -1,5 +1,6 @@
 require 'cgi'
 require 'time'
+require 'json'
 require 'slack'
 require 'ruboty/adapters/base'
 
@@ -27,12 +28,23 @@ module Ruboty
 
         return unless channel
 
-        realtime.send_message(
-          type: 'message',
-          channel: channel,
-          text: message[:code] ?  "```\n#{message[:body]}\n```" : resolve_send_mention(message[:body]),
-          mrkdwn: true
-        )
+        if message[:attachments] && !message[:attachments].empty?
+          client.chat_postMessage(
+            channel: channel,
+            text: message[:code] ?  "```\n#{message[:body]}\n```" : message[:body],
+            parse: 'full',
+            unfurl_links: true,
+            as_user: true,
+            attachments: message[:attachments].to_json
+          )
+        else
+          realtime.send_message(
+            type: 'message',
+            channel: channel,
+            text: message[:code] ?  "```\n#{message[:body]}\n```" : resolve_send_mention(message[:body]),
+            mrkdwn: true
+          )
+        end
       end
 
       private


### PR DESCRIPTION
I want to send attachments ! :pray:
### Example

``` ruby
class AttachmentTest < Ruboty::Handlers::Base
  on /attachment/, name: 'attachment'

  def attachment(message)
    message.reply('attachment test', {
      attachments: [
        {
          fallback: 'ruboty-slack_rtm https://github.com/rosylilly/ruboty-slack_rtm',
          title: 'ruboty-slack_rtm',
          title_link: 'https://github.com/rosylilly/ruboty-slack_rtm',
          text: 'Slack(real time api) adapter for ruboty.'
        }
      ]
    })
  end
end
```

![2016-10-26 2 19 55](https://cloud.githubusercontent.com/assets/1131422/19696804/b5001552-9b23-11e6-9304-abbef09ba0bc.png)
