### PR TITLE
Fix NoMethodError: undefined method `enq' for nil:NilClass

### DIFF
--- a/lib/ruboty/slack_rtm/client.rb
+++ b/lib/ruboty/slack_rtm/client.rb
@@ -7,9 +7,8 @@ module Ruboty
       CONNECTION_CLOSED = Object.new
 
       def initialize(websocket_url:)
-        @client = create_client(websocket_url.to_s)
-
         @queue = Queue.new
+        @client = create_client(websocket_url.to_s)
       end
 
       def send_message(data)


### PR DESCRIPTION
When cutting the connection with the slack expires, an error occured [here](https://github.com/rosylilly/ruboty-slack_rtm/blob/master/lib/ruboty/slack_rtm/client.rb#L60).

```
55:           queue = @queue
56:           client.on(:close) do
57:             Ruboty.logger.info('Disconnected')
58:             # XXX: This block is called via BasicObject#instance_exec from
59:             # EventEmitter, so `@queue` isn't visible here.
60:             binding.pry
61:             queue.enq(CONNECTION_CLOSED)
62:           end
63:         end
64:       end

[4] pry(#<WebSocket::Client::Simple::Client>)> queue.enq(CONNECTION_CLOSED)
NoMethodError: undefined method `enq' for nil:NilClass
from (pry):1:in `block (2 levels) in create_client'
```

Therefore, the ruboty process didn't finish normally.