### PR TITLE
Convert id to positive number of 32 bit signed integer

### DIFF
--- a/lib/ruboty/slack_rtm/client.rb
+++ b/lib/ruboty/slack_rtm/client.rb
@@ -12,7 +12,7 @@ module Ruboty
       end
 
       def send_message(data)
-        data[:id] = Time.now.to_i * 10 + rand(10)
+        data[:id] = (Time.now.to_i * 10 + rand(10)) % (1 << 31)
         @queue.enq(data.to_json)
       end
 


### PR DESCRIPTION
I tried it with several teams, it seems that the upper limit of message id has been changed to a positive number of 32 bit signed integer(0 - 2147483647).