### PR TITLE
update `slack-api` gem and use `rtm.connect` method

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -82,7 +82,7 @@ module Ruboty
 
       def url
         @url ||= begin
-          response = Net::HTTP.post_form(URI.parse('https://slack.com/api/rtm.start'), token: ENV['SLACK_TOKEN'])
+          response = Net::HTTP.post_form(URI.parse('https://slack.com/api/rtm.connect'), token: ENV['SLACK_TOKEN'])
           body = JSON.parse(response.body)
 
           URI.parse(body['url'])

--- a/lib/ruboty/slack_rtm/version.rb
+++ b/lib/ruboty/slack_rtm/version.rb
@@ -1,5 +1,5 @@
 module Ruboty
   module SlackRTM
-    VERSION = '2.7.2'
+    VERSION = '2.8.0'
   end
 end

--- a/ruboty-slack_rtm.gemspec
+++ b/ruboty-slack_rtm.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '>= 0.28.0'
 
   spec.add_dependency 'ruboty', '>= 1.1.4'
-  spec.add_dependency 'slack-api', '~> 1.2'
+  spec.add_dependency 'slack-api', '~> 1.6'
   spec.add_dependency 'websocket-client-simple', '~> 0.3.0'
 end


### PR DESCRIPTION
- update `slack-api` gem
- use `rtm.connect` method

Slack strongly recommends using the `rtm.connect` method instead of the old `rtm.start` method.
ref: https://api.slack.com/changelog/2017-04-start-using-rtm-connect-and-stop-using-rtm-start