### PR TITLE
Added reactions.add methods

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -47,6 +47,10 @@ module Ruboty
         end
       end
 
+      def add_reaction(reaction, channel_id, timestamp)
+        client.reactions_add(name: reaction, channel: channel_id, timestamp: timestamp)
+      end
+
       private
 
       def init

--- a/lib/ruboty/message.rb
+++ b/lib/ruboty/message.rb
@@ -1,0 +1,9 @@
+module Ruboty
+  class Message
+    def add_reaction(reaction)
+      channel_id = @original[:channel]["id"]
+      timestamp  = @original[:time].to_f
+      robot.add_reaction(reaction, channel_id, timestamp)
+    end
+  end
+end

--- a/lib/ruboty/robot.rb
+++ b/lib/ruboty/robot.rb
@@ -1,0 +1,10 @@
+module Ruboty
+  class Robot
+    delegate :add_reaction, to: :adapter
+
+    def add_reaction(reaction, channel_id, timestamp)
+      adapter.add_reaction(reaction, channel_id, timestamp)
+      true
+    end
+  end
+end

--- a/lib/ruboty/slack_rtm.rb
+++ b/lib/ruboty/slack_rtm.rb
@@ -1,3 +1,5 @@
 require 'ruboty/slack_rtm/version'
 require 'ruboty/slack_rtm/client'
 require 'ruboty/adapters/slack_rtm'
+require_relative 'robot'
+require_relative 'message'


### PR DESCRIPTION
I want to use the [reaction.add methods](https://api.slack.com/methods/reactions.add) as follows.

```
message.add_reaction("+1")
```
