### PR TITLE
Let bot use client.postMessage for message with no attachment

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -49,10 +49,10 @@ module Ruboty
             initial_comment: message[:body] || ''
           )
         else
-          realtime.send_message(
-            type: 'message',
+          client.chat_postMessage(
             channel: channel,
             text: message[:code] ?  "```\n#{message[:body]}\n```" : resolve_send_mention(message[:body]),
+            as_user: true,
             mrkdwn: true
           )
         end


### PR DESCRIPTION
~via RTM API, bot's normal message(with no attachment, file) will be treat like:~
Deleted wrong information. I'm sorry...

The patch will provide:
- All messages from bot will have `type` (consistency)
- Enable to run ruboty command via `ruboty-echo` <- What I want

RTM client will receive following as the response of message it sent:

```
{
  "ok":true,
  "reply_to":217505643,
  "ts":"1524989118.000002",
  "text":"hello"
}
```

Please notice there is no `type`.
Meaning to say, ruboty can't recognize message from itself.

This behavior could be a problem when triggering ruboty command via ruboty-echo.

At least with ruboty, this behavior is not necessary because all messages are
handled in a same way. To solve this, the patch let ruboty use
postMessage instead of RTM client's send message

How do you think? @rosylilly 
I will add env variable flag if you don't want to enable by default.