### PR TITLE
Resolve mention by display name when send message

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -241,7 +241,7 @@ module Ruboty
           msg = "@#{mention}"
 
           @user_info_caches.each_pair do |id, user|
-            if user['name'].downcase == mention.downcase
+            if [user['name'].downcase, user['profile']['display_name'].downcase].include?(mention.downcase)
               msg = "<@#{id}>"
             end
           end


### PR DESCRIPTION
ruboty-slack_rtm resolve mention by `name`, but slack display user name by `display_name` if `display_name` is available