### PR TITLE
bind before restarting main_loop

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -97,6 +97,8 @@ module Ruboty
           break unless ENV['SLACK_AUTO_RECONNECT']
           @url = nil
           @realtime = nil
+          sleep 3
+          bind
         end
       end
 


### PR DESCRIPTION
Hi there. 
I use this gem at my slack workplace. it's so helpful for me, thank you!

Btw, I might have found a problem about this.
Sometimes slack_rtm stopped even the process was alive.
and it was after reconnect.
I think it is because there is no `bind` for `@realtime` after reconnect.

I hope this simple change fixes it.
Thank you.