### PR TITLE
fix: duplicate frozen string

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -237,7 +237,7 @@ module Ruboty
       end
 
       def resolve_send_mention(text)
-        text = text.to_s
+        text = text.dup.to_s
         text.gsub!(/@(?<mention>[0-9a-z._-]+)/) do |_|
           mention = Regexp.last_match[:mention]
           msg = "@#{mention}"


### PR DESCRIPTION
Error causes on my Ruboty.
Fix them.

```
2019-08-30T00:41:57.639076+00:00 app[bot.1]: E, [2019-08-30T09:41:57.638958 #4] ERROR -- : FrozenError: can't modify frozen String
2019-08-30T00:41:57.639121+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.6.0/gems/ruboty-slack_rtm-3.1.1/lib/ruboty/adapters/slack_rtm.rb:241:in `gsub!'
2019-08-30T00:41:57.639125+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.6.0/gems/ruboty-slack_rtm-3.1.1/lib/ruboty/adapters/slack_rtm.rb:241:in `resolve_send_mention'
2019-08-30T00:41:57.639127+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.6.0/gems/ruboty-slack_rtm-3.1.1/lib/ruboty/adapters/slack_rtm.rb:54:in `say'
2019-08-30T00:41:57.639130+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.6.0/gems/ruboty-1.3.0/lib/ruboty/robot.rb:39:in `say'
2019-08-30T00:41:57.639132+00:00 app[bot.1]: /app/vendor/bundle/ruby/2.6.0/gems/ruboty-1.3.0/lib/ruboty/message.rb:44:in `reply'
```