### PR TITLE
Enable to expect reconnect when exception occurred in Thread

### DIFF
--- a/lib/ruboty/slack_rtm/client.rb
+++ b/lib/ruboty/slack_rtm/client.rb
@@ -65,7 +65,13 @@ module Ruboty
         Thread.start do
           loop do
             sleep(30)
-            @client.send('', type: 'ping')
+            begin
+              @client.send('', type: 'ping')
+            rescue => e
+              Ruboty.logger.error("#{e.class}: #{e.message}\n#{e.backtrace.join("\n")}")
+              @queue.enq(CONNECTION_CLOSED)
+              break
+            end
           end
         end
       end


### PR DESCRIPTION
### Problem

My bot become no reaction every day (maybe after 8 hours from started).

Then the bot output error log like bellow:

```
#<Thread:0x000055788f9be418@/app/vendor/bundle/ruby/2.6.0/gems/ruboty-slack_rtm-3.2.0/lib/ruboty/slack_rtm/client.rb:65 run> terminated with exception (report_on_exception is true):
/usr/local/lib/ruby/2.6.0/openssl/buffering.rb:322:in `syswrite': SSL_write (OpenSSL::SSL::SSLError)
	from /usr/local/lib/ruby/2.6.0/openssl/buffering.rb:322:in `do_write'
	from /usr/local/lib/ruby/2.6.0/openssl/buffering.rb:339:in `block in write'
	from /usr/local/lib/ruby/2.6.0/openssl/buffering.rb:338:in `each'
	from /usr/local/lib/ruby/2.6.0/openssl/buffering.rb:338:in `inject'
	from /usr/local/lib/ruby/2.6.0/openssl/buffering.rb:338:in `write'
	from /app/vendor/bundle/ruby/2.6.0/gems/websocket-client-simple-0.3.0/lib/websocket-client-simple/client.rb:75:in `send'
	from /app/vendor/bundle/ruby/2.6.0/gems/ruboty-slack_rtm-3.2.0/lib/ruboty/slack_rtm/client.rb:68:in `block (2 levels) in keep_connection'
	from /app/vendor/bundle/ruby/2.6.0/gems/ruboty-slack_rtm-3.2.0/lib/ruboty/slack_rtm/client.rb:66:in `loop'
	from /app/vendor/bundle/ruby/2.6.0/gems/ruboty-slack_rtm-3.2.0/lib/ruboty/slack_rtm/client.rb:66:in `block in keep_connection'
```

In `Thread` started by `Ruboty::SlackRTM::Client#keep_connection`, `WebSocket::Client::Simple#send` may occur exception.

https://github.com/rosylilly/ruboty-slack_rtm/blob/040541fddbc0e98128f8cce318af6abc7951d128/lib/ruboty/slack_rtm/client.rb#L64-L71

By default, its unhandled exception crashes `Thread` but its exception not propagate.

The bot will keep waiting message even if WebSocket connection disconnected.

https://github.com/rosylilly/ruboty-slack_rtm/blob/040541fddbc0e98128f8cce318af6abc7951d128/lib/ruboty/slack_rtm/client.rb#L35-L45