### PR TITLE
Put 'thread_ts' only when it's provided.

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -30,7 +30,6 @@ module Ruboty
         return unless channel
 
         args = {
-          channel: channel,
           as_user: true
         }
         if message[:thread_ts] || (message[:original] && message[:original][:thread_ts])
@@ -39,6 +38,7 @@ module Ruboty
 
         if message[:attachments] && !message[:attachments].empty?
           args.merge!(
+            channel: channel,
             text: message[:code] ? "```\n#{message[:body]}\n```" : message[:body],
             parse: message[:parse] || 'full',
             unfurl_links: true,
@@ -48,6 +48,7 @@ module Ruboty
         elsif message[:file]
           path = message[:file][:path]
           args.merge!(
+            channels: channel,
             file: Faraday::UploadIO.new(path, message[:file][:content_type]),
             title: message[:file][:title] || path,
             filename: File.basename(path),
@@ -56,6 +57,7 @@ module Ruboty
           client.files_upload(args)
         else
           args.merge!(
+            channel: channel,
             text: message[:code] ? "```\n#{message[:body]}\n```" : resolve_send_mention(message[:body]),
             mrkdwn: true
           )

--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -29,35 +29,37 @@ module Ruboty
 
         return unless channel
 
+        args = {
+          channel: channel,
+          as_user: true
+        }
+        if message[:thread_ts] || (message[:original] && message[:original][:thread_ts])
+          args.merge!(thread_ts: message[:thread_ts] || message[:original][:thread_ts])
+        end
+
         if message[:attachments] && !message[:attachments].empty?
-          client.chat_postMessage(
-            channel: channel,
-            text: message[:code] ?  "```\n#{message[:body]}\n```" : message[:body],
+          args.merge!(
+            text: message[:code] ? "```\n#{message[:body]}\n```" : message[:body],
             parse: message[:parse] || 'full',
             unfurl_links: true,
-            as_user: true,
-            attachments: message[:attachments].to_json,
-            thread_ts: message[:thread_ts] || message[:original][:thread_ts]
+            attachments: message[:attachments].to_json
           )
+          client.chat_postMessage(args)
         elsif message[:file]
           path = message[:file][:path]
-          client.files_upload(
-            channels: channel,
-            as_user: true,
+          args.merge!(
             file: Faraday::UploadIO.new(path, message[:file][:content_type]),
             title: message[:file][:title] || path,
             filename: File.basename(path),
-            initial_comment: message[:body] || '',
-            thread_ts: message[:thread_ts] || message[:original][:thread_ts]
+            initial_comment: message[:body] || ''
           )
+          client.files_upload(args)
         else
-          client.chat_postMessage(
-            channel: channel,
-            text: message[:code] ?  "```\n#{message[:body]}\n```" : resolve_send_mention(message[:body]),
-            as_user: true,
-            mrkdwn: true,
-            thread_ts: message[:thread_ts] || message[:original][:thread_ts]
+          args.merge!(
+            text: message[:code] ? "```\n#{message[:body]}\n```" : resolve_send_mention(message[:body]),
+            mrkdwn: true
           )
+          client.chat_postMessage(args)
         end
       end
 


### PR DESCRIPTION
Hello!

After #38, 'robot.say(...)' requires us to pass 'thread_ts' directly or pass the original message with the 'thread_ts' attribute.
This change loosens the requirements and allows us to do ```robot.say(channel: "CHANNEL_ID", text: "Text")``` to post a simple message to a channel.
The behavior introduced in the PR #38 should not be changed by this change.

Could anyone take a look at this change? Thanks!