### PR TITLE
Use #conversations_info instead of #channels_info

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -329,7 +329,7 @@ module Ruboty
         @channel_info_caches[channel_id] ||= begin
           resp = case channel_id
             when /^C/
-              client.channels_info(channel: channel_id)
+              client.conversations_info(channel: channel_id)
             else
               {}
             end


### PR DESCRIPTION
https://api.slack.com/methods#channels is deprecated and currently returns the following message:

```json
{
  "ok": false,
  "error": "method_deprecated",
  "response_metadata": {
    "messages": [
      "[ERROR] This method is retired and can no longer be used. Please use conversations.info instead. Learn more: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api."
    ]
  }
}
```

Use https://api.slack.com/methods/conversations.info instead.
