### PR TITLE
Fix `#resolve_send_mention` when parameter is nil

### DIFF
--- a/lib/ruboty/adapters/slack_rtm.rb
+++ b/lib/ruboty/adapters/slack_rtm.rb
@@ -246,6 +246,7 @@ module Ruboty
       end
 
       def resolve_send_mention(text)
+        return '' if text.nil?
         text = text.dup.to_s
         text.gsub!(/@(?<mention>[0-9a-z._-]+)/) do |_|
           mention = Regexp.last_match[:mention]


### PR DESCRIPTION
`nil.to_s` returns frozen string when ruby version is 2.7 or higher.
So, if the argument of `#resolve_send_mention` is nil, an error will occur.
I added early return when text parameter in `#resolve_send_mention` is nil.
